### PR TITLE
#23 - GlobalControllerAdvice에서 에러메세지의 내용이 아닌 코드를 출력하게 변경.

### DIFF
--- a/backend/src/main/java/me/iksadnorth/insta/exception/GlobalControllerAdvice.java
+++ b/backend/src/main/java/me/iksadnorth/insta/exception/GlobalControllerAdvice.java
@@ -14,6 +14,6 @@ public class GlobalControllerAdvice {
     public ResponseEntity<?> errorHandler(InstaApplicationException e) {
         log.error("Error occurs {}", e.toString());
         return ResponseEntity.status(e.getErrorCode().getStatus())
-                .body(Response.error(e.toString()));
+                .body(Response.error(e.getErrorCode().name()));
     }
 }


### PR DESCRIPTION
ex) 비밀번호가 정확하지 않습니다. => INVALID_PASSWORD