### PR TITLE
#48 - 쿼리 최적화 작업

### DIFF
--- a/backend/src/main/java/me/iksadnorth/insta/controller/AccountController.java
+++ b/backend/src/main/java/me/iksadnorth/insta/controller/AccountController.java
@@ -10,9 +10,7 @@ import me.iksadnorth.insta.service.AccountService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -39,14 +37,21 @@ public class AccountController {
     }
 
     @PutMapping("/{id}")
-    public Response<Void> accountUpdate(@PathVariable Long id, @RequestBody AccountUpdateRequest request, Authentication auth) {
-        service.accountUpdate(id, request.toDto(), ((UserDetails) auth.getPrincipal()));
+    public Response<Void> accountUpdate(
+            @PathVariable Long id,
+            @RequestBody AccountUpdateRequest request,
+            @AuthenticationPrincipal AccountDto dto
+    ) {
+        service.accountUpdate(id, request.toDto(), dto);
         return Response.success();
     }
 
     @DeleteMapping("/{id}")
-    public Response<Void> accountDelete(@PathVariable Long id, Authentication auth) {
-        service.accountDelete(id, ((UserDetails) auth.getPrincipal()));
+    public Response<Void> accountDelete(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AccountDto dto
+    ) {
+        service.accountDelete(id, dto);
         return Response.success();
     }
 
@@ -101,27 +106,27 @@ public class AccountController {
     @PostMapping("/follow/{follower_id}")
     public Response<Void> accountFollow(
             @PathVariable Long follower_id,
-            Authentication auth
+            @AuthenticationPrincipal AccountDto dto
     ) {
-        service.doFollow(((UserDetails) auth.getPrincipal()), follower_id);
+        service.doFollow(dto, follower_id);
         return Response.success();
     }
 
     @GetMapping("/follow/{follower_id}")
     public Response<FollowReadResponse> accountIsFollow(
             @PathVariable Long follower_id,
-            Authentication auth
+            @AuthenticationPrincipal AccountDto dto
     ) {
-        Boolean isFollow = service.isFollow(((UserDetails) auth.getPrincipal()), follower_id);
+        Boolean isFollow = service.isFollow(dto, follower_id);
         return Response.success(FollowReadResponse.of(isFollow));
     }
 
     @DeleteMapping("/follow/{follower_id}")
     public Response<Void> accountUnFollow(
             @PathVariable Long follower_id,
-            Authentication auth
+            @AuthenticationPrincipal AccountDto dto
     ) {
-        service.undoFollow(((UserDetails) auth.getPrincipal()), follower_id);
+        service.undoFollow(dto, follower_id);
         return Response.success();
     }
 
@@ -152,10 +157,9 @@ public class AccountController {
     @GetMapping("/principal/articles/recommended")
     public Response<Page<ArticleReadResponse>> accountRecommended(
             @AuthenticationPrincipal AccountDto dto,
-            @PageableDefault Pageable pageable,
-            Authentication auth
+            @PageableDefault Pageable pageable
     ) {
-        Page<ArticleDto> dtos = service.loadExploreById(dto.getId(), pageable, (UserDetails) auth.getPrincipal());
+        Page<ArticleDto> dtos = service.loadExploreById(dto.getId(), pageable, dto);
         return Response.success(dtos.map(ArticleReadResponse::from));
     }
 

--- a/backend/src/main/java/me/iksadnorth/insta/controller/CommentController.java
+++ b/backend/src/main/java/me/iksadnorth/insta/controller/CommentController.java
@@ -1,21 +1,19 @@
 package me.iksadnorth.insta.controller;
 
 import lombok.RequiredArgsConstructor;
-import me.iksadnorth.insta.model.dto.ArticleDto;
+import me.iksadnorth.insta.model.dto.AccountDto;
 import me.iksadnorth.insta.model.dto.CommentDto;
-import me.iksadnorth.insta.model.request.ArticleCreateRequest;
-import me.iksadnorth.insta.model.request.ArticleUpdateRequest;
 import me.iksadnorth.insta.model.request.CommentCreateRequest;
 import me.iksadnorth.insta.model.request.CommentUpdateRequest;
-import me.iksadnorth.insta.model.response.ArticleReadResponse;
 import me.iksadnorth.insta.model.response.CommentReadResponse;
+import me.iksadnorth.insta.model.response.LikeReadResponse;
 import me.iksadnorth.insta.model.response.Response;
-import me.iksadnorth.insta.service.ArticleService;
 import me.iksadnorth.insta.service.CommentService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,27 +23,54 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
     private final CommentService service;
 
-    @PostMapping
-    public Response<Void> commentCreate(@PathVariable Long id, @RequestBody CommentCreateRequest request) {
-        service.commentCreate(request.toDto());
+    @PostMapping("/{id}/children")
+    public Response<Void> commentCreateToComment(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AccountDto dto,
+            @RequestBody CommentCreateRequest request) {
+        service.commentCreateToComment(request.getContent(), dto, id);
         return Response.success();
     }
 
-    @GetMapping("/{Id}")
+    @GetMapping("/{id}/children")
     public Response<Page<CommentReadResponse>> commentRead(@PathVariable Long id, @PageableDefault Pageable pageable) {
-        Page<CommentDto> dtos = service.commentRead(id, pageable);
+        Page<CommentDto> dtos = service.childrenRead(id, pageable);
         return Response.success(dtos.map(CommentReadResponse::from));
     }
 
-    @PutMapping("/{Id}")
+    @PutMapping("/{id}")
     public Response<Void> commentUpdate(@PathVariable Long id, @RequestBody CommentUpdateRequest request, Authentication auth) {
         service.commentUpdate(id, request.toDto(), ((UserDetails) auth.getPrincipal()));
         return Response.success();
     }
 
-    @DeleteMapping("/{Id}")
+    @DeleteMapping("/{id}")
     public Response<Void> commentDelete(@PathVariable Long id, Authentication auth) {
         service.commentDelete(id, ((UserDetails) auth.getPrincipal()));
+        return Response.success();
+    }
+
+    @PostMapping("/{id}/like")
+    public Response<Void> commentCreateLikes(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AccountDto dto) {
+        service.commentCreateLikes(dto, id);
+        return Response.success();
+    }
+
+    @GetMapping("/{id}/like")
+    public Response<LikeReadResponse> commentIsLikes(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AccountDto dto) {
+        Boolean isLikes = service.commentIsLikes(dto, id);
+        return Response.success(LikeReadResponse.of(isLikes));
+    }
+
+    @DeleteMapping("/{id}/like")
+    public Response<Void> commentDeleteLikes(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AccountDto dto) {
+        service.commentDeleteLikes(dto, id);
         return Response.success();
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/model/dto/AccountDto.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/dto/AccountDto.java
@@ -3,7 +3,6 @@ package me.iksadnorth.insta.model.dto;
 import lombok.*;
 import me.iksadnorth.insta.model.entity.Account;
 import me.iksadnorth.insta.type.RoleType;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -54,6 +53,10 @@ public class AccountDto implements UserDetails {
     }
 
     public static AccountDto fromEntity(Account entity) {
+        return fromEntity(entity, null, null, null);
+    }
+
+    public static AccountDto fromInnerEntity(Account entity) {
         return fromEntity(entity, null, null, null);
     }
 

--- a/backend/src/main/java/me/iksadnorth/insta/model/dto/ArticleDto.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/dto/ArticleDto.java
@@ -2,6 +2,7 @@ package me.iksadnorth.insta.model.dto;
 
 import lombok.*;
 import me.iksadnorth.insta.model.entity.Article;
+import me.iksadnorth.insta.utils.ProxyHandler;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,28 +48,17 @@ public class ArticleDto {
     }
 
     public static ArticleDto fromEntity(Article entity) {
-        return ArticleDto.builder()
-                .id(entity.getId())
-                .createdAt(entity.getCreatedAt())
-                .deletedAt(entity.getDeletedAt())
-
-                .account(AccountDto.fromEntity(entity.getAccount()))
-                .image(ImageDto.fromEntity(entity.getImage()))
-                .content(entity.getContent())
-                .isHideLikesAndViews(entity.getIsHideLikesAndViews())
-                .isAllowedComments(entity.getIsAllowedComments())
-
-                .build();
+        return ArticleDto.fromEntity(entity, null, null);
     }
 
-    public static ArticleDto fromEntity(Article entity, Long numComments, Long numLikes, Long numViews) {
+    public static ArticleDto fromEntity(Article entity, Long numComments, Long numLikes) {
         return ArticleDto.builder()
                 .id(entity.getId())
                 .createdAt(entity.getCreatedAt())
                 .deletedAt(entity.getDeletedAt())
 
-                .account(AccountDto.fromEntity(entity.getAccount()))
-                .image(ImageDto.fromEntity(entity.getImage()))
+                .account(ProxyHandler.of(entity.getAccount()).map(AccountDto::fromEntity).orElse(null))
+                .image(ProxyHandler.of(entity.getImage()).map(ImageDto::fromEntity).orElse(null))
                 .content(entity.getContent())
                 .isHideLikesAndViews(entity.getIsHideLikesAndViews())
                 .isAllowedComments(entity.getIsAllowedComments())

--- a/backend/src/main/java/me/iksadnorth/insta/model/dto/CommentDto.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/dto/CommentDto.java
@@ -1,8 +1,8 @@
 package me.iksadnorth.insta.model.dto;
 
 import lombok.*;
-import me.iksadnorth.insta.model.entity.Article;
 import me.iksadnorth.insta.model.entity.Comment;
+import me.iksadnorth.insta.utils.ProxyHandler;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -24,29 +24,32 @@ public class CommentDto {
     private final CommentDto parent;
     private final String content;
 
+    // Service를 위한 속성들.
+    private  final Long numLikes;
+    private  final Long numChildren;
+
     public Comment toEntity() {
         Comment entity = new Comment();
         entity.setId(id);
         entity.setCreatedAt(createdAt);
         entity.setDeletedAt(deletedAt);
 
-        entity.setArticle(article.toEntity());
-        entity.setParent(parent.toEntity());
+        entity.setArticle(Optional.ofNullable(article).map(ArticleDto::toEntity).orElse(null));
+        entity.setParent(Optional.ofNullable(parent).map(CommentDto::toEntity).orElse(null));
         entity.setContent(content);
 
         return entity;
     }
 
     public static CommentDto fromEntity(Comment entity) {
-        if(entity == null) { return null; }
         return CommentDto.builder()
                 .id(entity.getId())
                 .createdAt(entity.getCreatedAt())
                 .deletedAt(entity.getDeletedAt())
 
-                .account(AccountDto.fromEntity(entity.getAccount()))
-                .article(ArticleDto.fromEntity(entity.getArticle()))
-                .parent(CommentDto.fromEntity(entity.getParent()))
+                .account(ProxyHandler.of(entity.getAccount()).map(AccountDto::fromEntity).orElse(null))
+                .article(ProxyHandler.of(entity.getArticle()).map(ArticleDto::fromEntity).orElse(null))
+                .parent(ProxyHandler.of(entity.getParent()).map(CommentDto::fromEntity).orElse(null))
                 .content(entity.getContent())
 
                 .build();
@@ -62,5 +65,34 @@ public class CommentDto {
                 .parent(parent)
                 .content(Optional.ofNullable(dto.getContent()).orElse(content))
                 .build();
+    }
+
+    public CommentDto withNum(Long numLikes, Long numChildren) {
+        return CommentDto.builder()
+                .id(id)
+                .createdAt(createdAt)
+                .deletedAt(deletedAt)
+
+                .account(account)
+                .article(article)
+                .parent(parent)
+                .content(content)
+
+                .numLikes(numLikes)
+                .numChildren(numChildren)
+                .build();
+    }
+
+    public static CommentDto of(String content, AccountDto accountDto, ArticleDto articleDto, CommentDto parentDto) {
+        return CommentDto.builder()
+                .account(accountDto)
+                .article(articleDto)
+                .parent(parentDto)
+                .content(content)
+                .build();
+    }
+
+    public static CommentDto of(String content, AccountDto accountDto, ArticleDto articleDto) {
+        return CommentDto.of(content, accountDto, articleDto, null);
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/model/dto/FollowDto.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/dto/FollowDto.java
@@ -1,17 +1,10 @@
 package me.iksadnorth.insta.model.dto;
 
 import lombok.*;
-import me.iksadnorth.insta.model.entity.Account;
 import me.iksadnorth.insta.model.entity.Follow;
-import me.iksadnorth.insta.type.RoleType;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
+import me.iksadnorth.insta.utils.ProxyHandler;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
 
 @ToString
 @EqualsAndHashCode(of = {"id"})
@@ -41,13 +34,13 @@ public class FollowDto {
     }
 
     public static FollowDto fromEntity(Follow entity) {
-        return new FollowDto(
-                entity.getId(),
-                entity.getCreatedAt(),
-                entity.getDeletedAt(),
+        return FollowDto.builder()
+                .id(entity.getId())
+                .createdAt(entity.getCreatedAt())
+                .deletedAt(entity.getDeletedAt())
 
-                AccountDto.fromEntity(entity.getFollower()),
-                AccountDto.fromEntity(entity.getFollowee())
-        );
+                .follower(ProxyHandler.of(entity.getFollower()).map(AccountDto::fromEntity).orElse(null))
+                .followee(ProxyHandler.of(entity.getFollowee()).map(AccountDto::fromEntity).orElse(null))
+                .build();
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/model/dto/HashtagDto.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/dto/HashtagDto.java
@@ -4,6 +4,7 @@ import lombok.*;
 import me.iksadnorth.insta.model.entity.Hashtag;
 import me.iksadnorth.insta.model.entity.View;
 import me.iksadnorth.insta.model.mappinginterface.HashtagNameMapping;
+import me.iksadnorth.insta.utils.ProxyHandler;
 
 import java.time.LocalDateTime;
 
@@ -35,14 +36,13 @@ public class HashtagDto {
     }
 
     public static HashtagDto fromEntity(Hashtag entity) {
-        return new HashtagDto(
-                entity.getId(),
-                entity.getCreatedAt(),
-                entity.getDeletedAt(),
-
-                entity.getName(),
-                ArticleDto.fromEntity(entity.getArticle())
-        );
+        return HashtagDto.builder()
+                .id(entity.getId())
+                .createdAt(entity.getCreatedAt())
+                .deletedAt(entity.getDeletedAt())
+                .name(entity.getName())
+                .article(ProxyHandler.of(entity.getArticle()).map(ArticleDto::fromEntity).orElse(null))
+                .build();
     }
 
     public static HashtagDto fromNameMapping(HashtagNameMapping hashtagNameMapping) {

--- a/backend/src/main/java/me/iksadnorth/insta/model/dto/LikeDto.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/dto/LikeDto.java
@@ -2,6 +2,7 @@ package me.iksadnorth.insta.model.dto;
 
 import lombok.*;
 import me.iksadnorth.insta.model.entity.Likes;
+import me.iksadnorth.insta.utils.ProxyHandler;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -36,14 +37,27 @@ public class LikeDto {
     }
 
     public static LikeDto fromEntity(Likes entity) {
-        return new LikeDto(
-                entity.getId(),
-                entity.getCreatedAt(),
-                entity.getDeletedAt(),
+        return LikeDto.builder()
+                .id(entity.getId())
+                .createdAt(entity.getCreatedAt())
+                .deletedAt(entity.getDeletedAt())
+                .account(ProxyHandler.of(entity.getAccount()).map(AccountDto::fromEntity).orElse(null))
+                .article(ProxyHandler.of(entity.getArticle()).map(ArticleDto::fromEntity).orElse(null))
+                .comment(ProxyHandler.of(entity.getComment()).map(CommentDto::fromEntity).orElse(null))
+                .build();
+    }
 
-                AccountDto.fromEntity(entity.getAccount()),
-                ArticleDto.fromEntity(entity.getArticle()),
-                CommentDto.fromEntity(entity.getComment())
-        );
+    public static LikeDto of(AccountDto account, ArticleDto article) {
+        return LikeDto.builder()
+                .account(account)
+                .article(article)
+                .build();
+    }
+
+    public static LikeDto of(AccountDto account, CommentDto comment) {
+        return LikeDto.builder()
+                .account(account)
+                .comment(comment)
+                .build();
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/model/entity/Comment.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/entity/Comment.java
@@ -9,18 +9,19 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Setter
 @Getter
 @NoArgsConstructor
-@SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() WHERE id=?")
+@SQLDelete(sql = "UPDATE comments SET deleted_at = NOW() WHERE id=?")
 @Where(clause = "deleted_at is NULL")
-@Table(name = "comment")
+@Table(name = "comments")
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Comment extends BaseEntity {
     @CreatedBy
-    @ManyToOne @JoinColumn(name = "", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "", nullable = false)
     private Account account;
 
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "article_id", nullable = false)
@@ -30,4 +31,7 @@ public class Comment extends BaseEntity {
     private Comment parent;
 
     private String content;
+
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    private List<Likes> likes;
 }

--- a/backend/src/main/java/me/iksadnorth/insta/model/entity/Image.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/entity/Image.java
@@ -7,10 +7,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Setter
 @Getter

--- a/backend/src/main/java/me/iksadnorth/insta/model/response/ArticleReadResponse.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/response/ArticleReadResponse.java
@@ -18,10 +18,11 @@ public class ArticleReadResponse {
     private final ImageDto image;
     private final String content;
 
-    // TODO: 아래 칼럼들에 대해서도 작업하기
+    private final Boolean isHideLikesAndViews;
+    private final Boolean isAllowedComments;
+
     private final Long numComments;
     private final Long numLikes;
-    private final Long numViews;
 
     public static ArticleReadResponse from(ArticleDto dto) {
         return new ArticleReadResponse(
@@ -32,9 +33,11 @@ public class ArticleReadResponse {
                 dto.getImage(),
                 dto.getContent(),
 
+                dto.getIsHideLikesAndViews(),
+                dto.getIsAllowedComments(),
+
                 dto.getNumComments(),
-                dto.getNumLikes(),
-                dto.getNumViews()
+                dto.getNumLikes()
         );
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/model/response/CommentReadResponse.java
+++ b/backend/src/main/java/me/iksadnorth/insta/model/response/CommentReadResponse.java
@@ -2,6 +2,7 @@ package me.iksadnorth.insta.model.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import me.iksadnorth.insta.model.dto.AccountDto;
 import me.iksadnorth.insta.model.dto.ArticleDto;
 import me.iksadnorth.insta.model.dto.CommentDto;
 
@@ -10,17 +11,25 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public class CommentReadResponse {
+    private final Long id;
+    private final AccountDto account;
     private final LocalDateTime createdAt;
     private final ArticleDto article;
     private final CommentDto parent;
     private final String content;
+    private final Long numLikes;
+    private final Long numChildren;
 
     public static CommentReadResponse from(CommentDto dto) {
         return new CommentReadResponse(
+                dto.getId(),
+                dto.getAccount(),
                 dto.getCreatedAt(),
                 dto.getArticle(),
                 dto.getParent(),
-                dto.getContent()
+                dto.getContent(),
+                dto.getNumLikes(),
+                dto.getNumChildren()
         );
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/repository/ArticleRepository.java
+++ b/backend/src/main/java/me/iksadnorth/insta/repository/ArticleRepository.java
@@ -3,12 +3,20 @@ package me.iksadnorth.insta.repository;
 import me.iksadnorth.insta.model.entity.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+    @EntityGraph(attributePaths = {"image", "account"}, type = EntityGraph.EntityGraphType.LOAD)
+    Optional<Article> findById(Long id);
     Long countByAccount_Id(Long accountId);
 
+    @EntityGraph(attributePaths = {"image", "account"}, type = EntityGraph.EntityGraphType.LOAD)
     @Query(
             "SELECT a FROM Article a " +
                     "LEFT JOIN a.account w " +
@@ -17,9 +25,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     )
     Page<Article> findFeedListById(Long id, Pageable pageable);
 
-    @Query(value = "SELECT * FROM article ORDER BY RAND()", nativeQuery = true)
-    Page<Article> findRandListById(Long id, Pageable pageable);
+    @Query("SELECT a FROM Article a JOIN FETCH a.image WHERE a.id IN :ids")
+    List<Article> findRandListById(Collection<Long> ids, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"image"}, type = EntityGraph.EntityGraphType.LOAD)
     Page<Article> findByAccount_Id(Long id, Pageable pageable);
 
     boolean existsByIdAndAccount_Email(Long id, String username);

--- a/backend/src/main/java/me/iksadnorth/insta/repository/CommentRepository.java
+++ b/backend/src/main/java/me/iksadnorth/insta/repository/CommentRepository.java
@@ -3,11 +3,22 @@ package me.iksadnorth.insta.repository;
 import me.iksadnorth.insta.model.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @EntityGraph(attributePaths = {"account"}, type= EntityGraph.EntityGraphType.LOAD)
+    Page<Comment> findByArticle_IdAndParentIsNull(Long id, Pageable pageable);
+    @EntityGraph(attributePaths = {"account", "parent"}, type= EntityGraph.EntityGraphType.LOAD)
     Page<Comment> findByParent_Id(Long id, Pageable pageable);
     boolean existsByIdAndAccount_Email(Long id, String email);
 
     Long countByArticle_Id(Long id);
+    Long countByParent_Id(Long id);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.article WHERE c.id = :id")
+    Optional<Comment> findByIdWithArticle(Long id);
 }

--- a/backend/src/main/java/me/iksadnorth/insta/repository/LikeRepository.java
+++ b/backend/src/main/java/me/iksadnorth/insta/repository/LikeRepository.java
@@ -9,8 +9,12 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     Long countByArticle_Id(Long id);
+    Long countByComment_Id(Long id);
 
     boolean existsByArticle_IdAndAccount_Email(Long id, String username);
+    boolean existsByAccount_IdAndComment_Id(Long uid, Long cid);
 
     Optional<Likes> findByArticle_IdAndAccount_Email(Long id, String username);
+
+    Optional<Likes> findByAccount_IdAndComment_Id(Long uid, Long cid);
 }

--- a/backend/src/main/java/me/iksadnorth/insta/service/CommentService.java
+++ b/backend/src/main/java/me/iksadnorth/insta/service/CommentService.java
@@ -2,8 +2,13 @@ package me.iksadnorth.insta.service;
 
 import me.iksadnorth.insta.exception.ErrorCode;
 import me.iksadnorth.insta.exception.InstaApplicationException;
+import me.iksadnorth.insta.model.dto.AccountDto;
+import me.iksadnorth.insta.model.dto.ArticleDto;
 import me.iksadnorth.insta.model.dto.CommentDto;
+import me.iksadnorth.insta.model.dto.LikeDto;
+import me.iksadnorth.insta.model.entity.Likes;
 import me.iksadnorth.insta.repository.CommentRepository;
+import me.iksadnorth.insta.repository.LikeRepository;
 import me.iksadnorth.insta.type.RoleType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -11,19 +16,66 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
 @Service
+@Transactional
 public class CommentService {
+    @Autowired ArticleService articleService;
     @Autowired CommentRepository repo;
+    @Autowired LikeRepository likeRepo;
 
-    public void commentCreate(CommentDto dto) {
-        repo.save(dto.toEntity());
+    public void commentCreateToArticle(String content, AccountDto accountDto, Long pid) {
+        ArticleDto articleDto = articleService.loadDtoById(pid);
+        CommentDto commentDto = CommentDto.of(content, accountDto, articleDto);
+        repo.save(commentDto.toEntity());
+    }
+
+    public void commentCreateToComment(String content, AccountDto accountDto, Long cid) {
+        CommentDto parentDto = commentReadByIdWithArticle(cid);
+        ArticleDto articleDto = parentDto.getArticle();
+        CommentDto commentDto = CommentDto.of(content, accountDto, articleDto, parentDto);
+        repo.save(commentDto.toEntity());
+    }
+
+    public CommentDto commentReadById(Long id) {
+        return repo.findById(id).map(CommentDto::fromEntity).orElseThrow(() -> {
+            throw new InstaApplicationException(
+                    ErrorCode.ID_NOT_FOUNDED,
+                    String.format("해당 Id값: %d", id)
+            );}
+        );
+    }
+
+    public CommentDto commentReadByIdWithArticle(Long id) {
+        return repo.findByIdWithArticle(id).map(CommentDto::fromEntity).orElseThrow(() -> {
+            throw new InstaApplicationException(
+                    ErrorCode.ID_NOT_FOUNDED,
+                    String.format("해당 Id값: %d", id)
+            );}
+        );
     }
 
     public Page<CommentDto> commentRead(Long id, Pageable pageable) {
-        return repo.findByParent_Id(id, pageable).map(CommentDto::fromEntity);
+        return repo.findByArticle_IdAndParentIsNull(id, pageable).map(comment -> {
+            Long numLikes = likeRepo.countByComment_Id(comment.getId());
+            Long numChildren = repo.countByParent_Id(comment.getId());
+
+            return CommentDto
+                    .fromEntity(comment)
+                    .withNum(numLikes, numChildren);
+        });
+    }
+
+    public Page<CommentDto> childrenRead(Long id, Pageable pageable) {
+        return repo.findByParent_Id(id, pageable).map(comment -> {
+            Long numLikes = likeRepo.countByComment_Id(comment.getId());
+            Long numChildren = repo.countByParent_Id(comment.getId());
+
+            return CommentDto.fromEntity(comment).withNum(numLikes, numChildren);
+        });
     }
 
     public void commentUpdate(Long id, CommentDto dto, UserDetails principal) {
@@ -90,5 +142,24 @@ public class CommentService {
         repo.save(
                 dtoQueried.overWriteWith(dto).toEntity()
         );
+    }
+
+    public void commentCreateLikes(AccountDto dto, Long id) {
+        CommentDto commentDto = commentReadById(id);
+        LikeDto likeDto = LikeDto.of(dto, commentDto);
+        likeRepo.save(likeDto.toEntity());
+    }
+
+    public void commentDeleteLikes(AccountDto dto, Long id) {
+        Likes likeEntity = likeRepo.findByAccount_IdAndComment_Id(dto.getId(), id)
+                .orElseThrow(() -> new InstaApplicationException(
+                        ErrorCode.ID_NOT_FOUNDED,
+                        String.format("해당 유저 Id와 댓글 Id: %s, %s", dto.getId(), id)
+                ));
+        likeRepo.delete(likeEntity);
+    }
+
+    public Boolean commentIsLikes(AccountDto dto, Long id) {
+        return likeRepo.existsByAccount_IdAndComment_Id(dto.getId(), id);
     }
 }

--- a/backend/src/main/java/me/iksadnorth/insta/service/HashtagService.java
+++ b/backend/src/main/java/me/iksadnorth/insta/service/HashtagService.java
@@ -10,8 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class HashtagService {
     @Autowired HashtagRepository repo;
     @Autowired ArticleRepository articleRepo;

--- a/backend/src/main/java/me/iksadnorth/insta/service/ImageService.java
+++ b/backend/src/main/java/me/iksadnorth/insta/service/ImageService.java
@@ -9,12 +9,14 @@ import me.iksadnorth.insta.repository.ImageRepository;
 import me.iksadnorth.insta.utils.NameGenerator.NameGenerator;
 import me.iksadnorth.insta.utils.fileManager.FileManager;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class ImageService {
     private final ImageRepository repo;

--- a/backend/src/main/java/me/iksadnorth/insta/utils/ProxyHandler.java
+++ b/backend/src/main/java/me/iksadnorth/insta/utils/ProxyHandler.java
@@ -1,0 +1,47 @@
+package me.iksadnorth.insta.utils;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class ProxyHandler<E> {
+    private final E entity;
+
+    public ProxyHandler(E entity) {
+        this.entity = entity;
+    }
+
+    public static <E> ProxyHandler<E> of(E entity) {
+        return new ProxyHandler<>(entity);
+    }
+
+    public static <E> ProxyHandler<E> empty() {
+        return new ProxyHandler<>(null);
+    }
+
+    public Boolean isProxy() {
+        return isProxy(entity);
+    }
+
+    public static <E> Boolean isProxy(E entity) {
+        return Optional.ofNullable(entity)
+                .map(Object::getClass)
+                .map(Class::getName)
+                .map(String::toLowerCase)
+                .filter(s -> s.contains("hibernateproxy"))
+                .isPresent();
+    }
+
+    public Boolean isNull() {
+        return entity == null;
+    }
+
+    public <D> ProxyHandler<D> map(Function<? super E, ? extends D> mapper) {
+        Objects.requireNonNull(mapper);
+        return isNull() || isProxy() ? empty() : of(mapper.apply(this.entity));
+    }
+
+    public E orElse(E other) {
+        return isNull() || isProxy() ? other : this.entity;
+    }
+}

--- a/backend/src/main/java/me/iksadnorth/insta/utils/Zip.java
+++ b/backend/src/main/java/me/iksadnorth/insta/utils/Zip.java
@@ -1,0 +1,21 @@
+package me.iksadnorth.insta.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Zip {
+    public static <T> List<List<T>> zip(List<T>... lists) {
+        List<List<T>> zipped = new ArrayList<List<T>>();
+        for (List<T> list : lists) {
+            for (int i = 0, listSize = list.size(); i < listSize; i++) {
+                List<T> list2;
+                if (i >= zipped.size())
+                    zipped.add(list2 = new ArrayList<T>());
+                else
+                    list2 = zipped.get(i);
+                list2.add(list.get(i));
+            }
+        }
+        return zipped;
+    }
+}

--- a/backend/src/main/resources/application-common.yml
+++ b/backend/src/main/resources/application-common.yml
@@ -2,7 +2,9 @@ spring:
   config.activate.on-profile: "common"
   jpa:
     show-sql: true
-    properties.hibernate.format_sql: true
+    properties:
+      hibernate.format_sql: true
+      hibernate.jdbc.batch_size: 1000
 
 logging.level:
   root: INFO

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -35,3 +35,6 @@ INSERT INTO hashtag (name, article_id) VALUES ('tag2', 3);
 
 INSERT INTO hashtag (name, article_id) VALUES ('tag3', 3);
 INSERT INTO hashtag (name, article_id) VALUES ('tag3', 1);
+
+INSERT INTO comments (created_at, account_id, article_id, parent_id, content) VALUES (NOW(), 2, 6, null, '댓글 달기');
+INSERT INTO comments (created_at, account_id, article_id, parent_id, content) VALUES (NOW(), 1, 6, 1, '대댓글 달기');

--- a/backend/src/test/java/me/iksadnorth/insta/InstaApplicationTests.java
+++ b/backend/src/test/java/me/iksadnorth/insta/InstaApplicationTests.java
@@ -2,10 +2,9 @@ package me.iksadnorth.insta;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class InstaApplicationTests {
 

--- a/backend/src/test/java/me/iksadnorth/insta/controller/AccountControllerTest.java
+++ b/backend/src/test/java/me/iksadnorth/insta/controller/AccountControllerTest.java
@@ -142,7 +142,7 @@ class AccountControllerTest {
     void accountPutTest2() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.ID_NOT_FOUNDED))
-                .given(service).accountUpdate(any(Long.class), any(AccountDto.class), any(UserDetails.class));
+                .given(service).accountUpdate(any(Long.class), any(AccountDto.class), any(AccountDto.class));
 
         // when & then
         mvc.perform(
@@ -161,7 +161,7 @@ class AccountControllerTest {
     void accountPutTest3() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.OWNERSHIP_NOT_FOUNDED))
-                .given(service).accountUpdate(any(Long.class), any(AccountDto.class), any(UserDetails.class));
+                .given(service).accountUpdate(any(Long.class), any(AccountDto.class), any(AccountDto.class));
 
         // when & then
         mvc.perform(
@@ -208,7 +208,7 @@ class AccountControllerTest {
     void accountDeleteTest2() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.ID_NOT_FOUNDED))
-                .given(service).accountDelete(any(Long.class), any(UserDetails.class));
+                .given(service).accountDelete(any(Long.class), any(AccountDto.class));
 
         // when & then
         mvc.perform(delete(prefix + "/accounts/2"))
@@ -223,7 +223,7 @@ class AccountControllerTest {
     void accountDeleteTest3() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.OWNERSHIP_NOT_FOUNDED))
-                .given(service).accountDelete(any(Long.class), any(UserDetails.class));
+                .given(service).accountDelete(any(Long.class), any(AccountDto.class));
 
         // when & then
         mvc.perform(delete(prefix + "/accounts/1"))
@@ -317,7 +317,7 @@ class AccountControllerTest {
     void accountFollowTest4() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.DUPLICATED_FOLLOW))
-                .given(service).doFollow(any(UserDetails.class), any(Long.class));
+                .given(service).doFollow(any(AccountDto.class), any(Long.class));
 
         // when & then
         mvc.perform(post(prefix + "/accounts/follow/6"))
@@ -331,7 +331,7 @@ class AccountControllerTest {
     void accountFollowTest5() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.FOLLOW_NOT_FOUNDED))
-                .given(service).undoFollow(any(UserDetails.class), any(Long.class));
+                .given(service).undoFollow(any(AccountDto.class), any(Long.class));
 
         // when & then
         mvc.perform(delete(prefix + "/accounts/1/follow/6"))
@@ -371,7 +371,7 @@ class AccountControllerTest {
     @Test
     void accountArticlesTest3() throws Exception {
         // given
-        given(service.loadExploreById(any(Long.class), any(Pageable.class), any(UserDetails.class))).willReturn(Page.empty());
+        given(service.loadExploreById(any(Long.class), any(Pageable.class), any(AccountDto.class))).willReturn(Page.empty());
 
         // when & then
         mvc.perform(get(prefix + "/accounts/1/articles/recommended"))
@@ -399,7 +399,7 @@ class AccountControllerTest {
     void accountArticlesTest5() throws Exception {
         // given
         willThrow(new InstaApplicationException(ErrorCode.OWNERSHIP_NOT_FOUNDED)).given(service)
-                .loadExploreById(any(Long.class), any(Pageable.class), any(UserDetails.class));
+                .loadExploreById(any(Long.class), any(Pageable.class), any(AccountDto.class));
 
         // when & then
         mvc.perform(get(prefix + "/accounts/1/articles/recommended"))
@@ -413,7 +413,7 @@ class AccountControllerTest {
     @Fixture.SetMockAdmin
     void accountArticlesTest6() throws Exception {
         // given
-        given(service.loadExploreById(any(Long.class), any(Pageable.class), any(UserDetails.class)))
+        given(service.loadExploreById(any(Long.class), any(Pageable.class), any(AccountDto.class)))
                 .willReturn(Page.empty());
 
         // when & then

--- a/backend/src/test/java/me/iksadnorth/insta/controller/ArticleControllerTest.java
+++ b/backend/src/test/java/me/iksadnorth/insta/controller/ArticleControllerTest.java
@@ -9,6 +9,7 @@ import me.iksadnorth.insta.model.request.ArticleCreateRequest;
 import me.iksadnorth.insta.model.request.ArticleUpdateRequest;
 import me.iksadnorth.insta.service.AccountService;
 import me.iksadnorth.insta.service.ArticleService;
+import me.iksadnorth.insta.service.CommentService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -37,6 +38,7 @@ class ArticleControllerTest {
     @Autowired ObjectMapper mapper;
 
     @MockBean AccountService accountService;
+    @MockBean CommentService commentService;
     @MockBean ArticleService service;
     @InjectMocks ArticleController controller;
 
@@ -77,7 +79,7 @@ class ArticleControllerTest {
     @WithAnonymousUser
     void articleReadTest1() throws Exception {
         // given
-        given(service.articleRead(any(Long.class))).willReturn(fixture.getArticleDtos(0));
+        given(service.articleReadWithInfo(any(Long.class))).willReturn(fixture.getArticleDtos(0));
 
         // when & then
         mvc.perform(

--- a/backend/src/test/java/me/iksadnorth/insta/repository/ArticleRepositoryTest.java
+++ b/backend/src/test/java/me/iksadnorth/insta/repository/ArticleRepositoryTest.java
@@ -44,19 +44,6 @@ class ArticleRepositoryTest {
     }
 
     @Test
-    void findRandListById() {
-        // given
-        Long id = 1L;
-        Pageable pageable = PageRequest.of(0, 10);
-
-        // when & then
-        Page<Article> articles = repo.findRandListById(id, pageable);
-        articles.forEach(article -> {
-            log.trace(article.getContent());
-        });
-    }
-
-    @Test
     void findByAccount_Id() {
         // given
         Long id = 1L;

--- a/backend/src/test/java/me/iksadnorth/insta/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/me/iksadnorth/insta/repository/CommentRepositoryTest.java
@@ -1,0 +1,36 @@
+package me.iksadnorth.insta.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import me.iksadnorth.insta.config.EnableProjectJpaConfig;
+import me.iksadnorth.insta.model.dto.CommentDto;
+import me.iksadnorth.insta.model.entity.Comment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+@Slf4j
+@DisplayName("CommentRepo 테스트 - 직접 설정한 쿼리가 작동하는지 확인하는 테스트")
+@EnableProjectJpaConfig
+@ActiveProfiles("Test")
+@DataJpaTest
+class CommentRepositoryTest {
+    @Autowired CommentRepository repo;
+
+    @Test
+    void findByArticle_IdAndParentIsNull() {
+        // given
+        Long id = 6L;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when & then
+        Page<Comment> articles = repo.findByArticle_IdAndParentIsNull(id, pageable);
+        log.trace("총 {}개", articles.stream().count());
+
+        articles.map(CommentDto::fromEntity).forEach(article -> log.trace(article.toString()));
+    }
+}


### PR DESCRIPTION
1. @AuthenticationPrincipal 를 이용해서 로그인 사용자의 정보를 한번만 호출한다.
2. ProxyHandler를 만들어 Proxy 객체는 DTO 형변환 시, 무시하도록하기.
3. Service 클래스들에 @transactional 추가 중복된 코드들 리팩토링.
4. 게시물 추천(loadExploreById @ AccountService)의 경우, 추천 알고리즘에 의해 id 값들을 받는다고 가정하고 그에 따라 출력하도록 수정.
5. @entitygraph를 이용해서 최대한 쿼리를 직접 작성하기를 피함.